### PR TITLE
グループ削除時にひもづく投稿を一括削除する

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,4 +2,5 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   validates :name, presence: true, uniqueness: true
+  has_many :posts, dependent: :delete_all
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ApplicationRecord
   mount_uploader :image, ImageUploader
+  belongs_to :group
 end


### PR DESCRIPTION
WHAT
・グループを削除した際に、そのグループに紐付く投稿を一括で削除する機能の実装

WHY
・データベースの容量節約のため
・グループ削除時に必要の無いデータを残さないようにするため
・アソシエーションを組んでいるため、外部キーが必要になりグループの削除時にエラーが発生してしまうため