### PR TITLE
中間テーブルの名前を変更

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,7 +10,7 @@ class GroupsController < ApplicationController
     @group = Group.new
     @group.users << current_user
   end
-
+  
   def create
     @group = Group.new(group_params)
     if @group.save

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 class Group < ApplicationRecord
-  has_many :group_users
-  has_many :users, through: :group_users
+  has_many :groups_users
+  has_many :users, through: :groups_users
   validates :name, presence: true, uniqueness: true
   has_many :posts, dependent: :delete_all
 end

--- a/app/models/groups_user.rb
+++ b/app/models/groups_user.rb
@@ -1,4 +1,4 @@
-class GroupUser < ApplicationRecord
+class GroupsUser < ApplicationRecord
   belongs_to :group
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :group_users
-  has_many :groups, through: :group_users
+  has_many :groups_users
+  has_many :groups, through: :groups_users
 end

--- a/db/migrate/20200127060246_change_group_users_to_groups_users.rb
+++ b/db/migrate/20200127060246_change_group_users_to_groups_users.rb
@@ -1,0 +1,5 @@
+class ChangeGroupUsersToGroupsUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :group_users, :groups_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_013727) do
-
-  create_table "group_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "group_id"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["group_id"], name: "index_group_users_on_group_id"
-    t.index ["user_id"], name: "index_group_users_on_user_id"
-  end
+ActiveRecord::Schema.define(version: 2020_01_27_060246) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true
+  end
+
+  create_table "groups_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_groups_users_on_group_id"
+    t.index ["user_id"], name: "index_groups_users_on_user_id"
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_013727) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "group_users", "groups"
-  add_foreign_key "group_users", "users"
+  add_foreign_key "groups_users", "groups"
+  add_foreign_key "groups_users", "users"
   add_foreign_key "posts", "groups"
 end


### PR DESCRIPTION
WHAT
・中間テーブルの名前を変更

WHY
・名前が複数系でなかったため